### PR TITLE
Input file handling

### DIFF
--- a/fields.f90
+++ b/fields.f90
@@ -621,6 +621,8 @@ module fields
    integer(ik) :: i,iatom,imode,natoms,alloc,Nparam,iparam,i_t
    integer(ik) :: Nbonds,Nangles,Ndihedrals,j,ispecies,imu,iterm,Ncoords,icoords
    character(len=4) :: char_j
+   integer :: arg_status, arg_length, arg_unit
+   character(:), allocatable :: arg
                                         ! in the symmetr. diag. routine 
    !
    !
@@ -731,7 +733,17 @@ module fields
    !
    Jrot = 0
    !
-   call input_options(echo_lines=.true.,error_flag=1)
+   arg_unit = 5
+   call get_command_argument(1, status=arg_status, length=arg_length)
+   if (arg_status == 0) then
+     allocate( character(arg_length) :: arg )
+     call get_command_argument(1, status=arg_status, value=arg)
+     if (arg_status == 0) then
+       open(newunit=arg_unit, file=arg, status='old')
+     end if
+   end if
+   !
+   call input_options(echo_lines=.true.,error_flag=1, default_unit=arg_unit)
    !
    ! read the general input 
    !

--- a/input.f90
+++ b/input.f90
@@ -527,12 +527,12 @@ END SUBROUTINE getargs
 !-----------------------------------------------------------------------
 
 SUBROUTINE input_options(default,clear_if_null,skip_blank_lines,       &
-    echo_lines, error_flag, concat_string)
+    echo_lines, error_flag, concat_string, default_unit)
 
 IMPLICIT NONE
 LOGICAL, OPTIONAL :: default, clear_if_null, skip_blank_lines,         &
     echo_lines
-INTEGER, OPTIONAL :: error_flag
+INTEGER, OPTIONAL :: error_flag, default_unit
 CHARACTER(LEN=*), optional :: concat_string
 
 if (present(default)) then
@@ -561,6 +561,9 @@ if (present(concat_string)) then
       ("Concatenation string must be 8 characters or fewer",.false.)
   concat=concat_string
   lc=len(trim(concat_string))
+endif
+if (present(default_unit)) then
+  ir=default_unit
 endif
 
 END SUBROUTINE input_options


### PR DESCRIPTION
This patch allows the input file to be passed on the command line:
`./trove.x file.input`
rather than read from stdin
`./trove.x <file.input`

If no input file is given on the command line then it defaults to the current behaviour of reading the input file from stdin.  