### PR TITLE
Enable -fallow-argument-mismatch for gcc versions >= 10

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,8 +36,8 @@ else ifeq ($(strip $(COMPILER)),gfortran)
 	FOR = gfortran
 	FFLAGS = -cpp -std=gnu -fopenmp -march=native -ffree-line-length-512 -fcray-pointer -I$(OBJDIR) -J$(OBJDIR)
 
-	GCC_VERSION=$(shell gcc -v 2>&1 | grep -Po "^gcc version \K(\d+)")
-	ifeq ($(GCC_VERSION),10)
+	GCC_VERSION_GT_10 := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 10)
+	ifeq "${GCC_VERSION_GT_10}" "1"
 		# gcc 10 complains about mismatched argument types
 		FFLAGS += -fallow-argument-mismatch
 	endif


### PR DESCRIPTION
This PR enables `-fallow-argument-mismatch` for all versions of GCC where it is required for compatibility (i.e. GCC versions >= 10).