### PR TITLE
Include Intel compiler and MPI in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     name: TROVE ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.compiler }} - MPI:${{ matrix.mpi }}
     env:
       OMP_NUM_THREADS: 1
+      USE_MPI: ${{ matrix.mpi && 1 || 0 }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -53,8 +54,6 @@ jobs:
 
       - name: Setup Intel compiler and MPI
         if: ${{ matrix.compiler  == 'intel' && steps.cache_intel.outputs.cache-hit != 'true'}}
-        env:
-          USE_MPI: ${{ matrix.mpi && 1 || 0 }}
         run: |
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
@@ -82,8 +81,6 @@ jobs:
 
       - name: Build (intel)
         if: ${{ matrix.compiler == 'intel' }}
-        env:
-          MPI_PARAM: ${{ matrix.mpi && 'USE_MPI=1' || ''}}
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           source /opt/intel/oneapi/setvars.sh
@@ -93,11 +90,10 @@ jobs:
           # mpif90 uses gfortran by default unless changed like this
           export I_MPI_F90=ifort
           ifort --version
-          make COMPILER=intel MODE=ci ${MPI_PARAM}
+          make COMPILER=intel MODE=ci USE_MPI=${USE_MPI}
 
       - name: Test
         env:
-          USE_MPI: ${{ matrix.mpi && 1 || 0 }}
           # nproc is used in the test script for the number of processes
           nproc: ${{ matrix.mpi && 2 || 1 }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           USE_MPI: ${{ matrix.mpi && 1 || 0 }}
           # nproc is used in the test script for the number of processes
-          nproc: ${{ matrix.mpi && 1 || 1 }}
+          nproc: ${{ matrix.mpi && 2 || 1 }}
         run: |
           if [[ -d "/opt/intel/oneapi" ]]; then
             source /opt/intel/oneapi/compiler/latest/env/vars.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,9 @@ jobs:
           make COMPILER=intel MODE=ci
 
       - name: Test
-        run: make test
+        run: |
+          if [[ -d "/opt/intel/oneapi" ]]; then
+            source /opt/intel/oneapi/compiler/latest/env/vars.sh
+            source /opt/intel/oneapi/setvars.sh
+          fi
+          make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build (intel)
         if: ${{ matrix.compiler == 'intel' }}
         env:
-          - MPI_PARAM: ${{ matrix.mpi && 'USE_MPI=1' || ''}}
+          MPI_PARAM: ${{ matrix.mpi && 'USE_MPI=1' || ''}}
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           source /opt/intel/oneapi/setvars.sh
@@ -87,9 +87,9 @@ jobs:
 
       - name: Test
         env:
-          - USE_MPI: ${{ matrix.mpi && 1 || 0 }}
+          USE_MPI: ${{ matrix.mpi && 1 || 0 }}
           # nproc is used in the test script for the number of processes
-          - nproc: ${{ matrix.mpi && 2 || 1 }}
+          nproc: ${{ matrix.mpi && 2 || 1 }}
         run: |
           if [[ -d "/opt/intel/oneapi" ]]; then
             source /opt/intel/oneapi/compiler/latest/env/vars.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           source /opt/intel/oneapi/setvars.sh
+          # MKL doesn't have a "latest" link so we can't hardcode the path
+          source $(find /opt/intel/oneapi/mkl/ -name "vars.sh")
+          # mpif90 uses gfortran by default unless changed like this
           export I_MPI_F90=ifort
           ifort --version
           make COMPILER=intel MODE=ci ${MPI_PARAM}
@@ -100,5 +103,6 @@ jobs:
           if [[ -d "/opt/intel/oneapi" ]]; then
             source /opt/intel/oneapi/compiler/latest/env/vars.sh
             source /opt/intel/oneapi/setvars.sh
+            source $(find /opt/intel/oneapi/mkl/ -name "vars.sh")
           fi
           make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           USE_MPI: ${{ matrix.mpi && 1 || 0 }}
           # nproc is used in the test script for the number of processes
-          nproc: ${{ matrix.mpi && 2 || 1 }}
+          nproc: ${{ matrix.mpi && 1 || 1 }}
         run: |
           if [[ -d "/opt/intel/oneapi" ]]; then
             source /opt/intel/oneapi/compiler/latest/env/vars.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      #- name: Cache benchmark data
-        #uses: actions/cache@v2
-        #env:
-          #cache-name: benchmark-data
-        #with:
-          #path: test/benchmarks
-          #key: benchmark-data
-
       - name: Restored cached Intel install
         id: cache_intel
         if: ${{ matrix.compiler == 'intel' }}
@@ -71,6 +63,8 @@ jobs:
           architecture: x64
 
       - name: Install Intel MKL
+        # MKL will have been installed alongside MPI if we're using that
+        if: ${{ !matrix.mpi }}
         run: sudo apt-get install -y intel-mkl
 
       - name: Build (gfortran)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,10 @@ jobs:
         run: sudo apt-get install -y intel-mkl
 
       - name: Build
+        env:
+          COMPILER: ${{ matrix.compiler == 'intel' && 'ifort' || 'gfortran' }}
         run: |
-          ${{ matrix.compiler }} --version
+          ${COMPILER} --version
           make COMPILER=${{ matrix.compiler }} MODE=ci
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
           sudo apt-get install -y intel-oneapi-compiler-fortran
           if [ ${USE_MPI} = 1 ]; then
-            sudo apt-get install -y intel-oneapi-mpi-devel
+            sudo apt-get install -y intel-oneapi-mpi-devel intel-oneapi-mkl-devel
           fi
 
       - name: Setup python
@@ -87,8 +87,9 @@ jobs:
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           source /opt/intel/oneapi/setvars.sh
-          # MKL doesn't have a "latest" link so we can't hardcode the path
-          source $(find /opt/intel/oneapi/mkl/ -name "vars.sh")
+          if [ -d "/opt/intel/oneapi/mkl" ]; then
+            source /opt/intel/oneapi/mkl/latest/env/vars.sh
+          fi
           # mpif90 uses gfortran by default unless changed like this
           export I_MPI_F90=ifort
           ifort --version
@@ -103,6 +104,8 @@ jobs:
           if [[ -d "/opt/intel/oneapi" ]]; then
             source /opt/intel/oneapi/compiler/latest/env/vars.sh
             source /opt/intel/oneapi/setvars.sh
-            source $(find /opt/intel/oneapi/mkl/ -name "vars.sh")
+            if [ ${USE_MPI} = 1 ]; then
+               source /opt/intel/oneapi/mkl/latest/env/vars.sh
+            fi
           fi
           make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ matrix.compiler == 'intel' }}
         uses: actions/cache@v2
         with:
-          key: oneapi-${{ matrix.os }}-${{ matrix.arch }}
+          key: oneapi-${{ matrix.os }}-${{ matrix.arch }}-MPI:{{ matrix.mpi }}
           path: |
             /opt/intel/oneapi/*
             !/opt/intel/oneapi/conda_channel
@@ -53,12 +53,17 @@ jobs:
 
       - name: Setup Intel compiler and MPI
         if: ${{ matrix.compiler  == 'intel' && steps.cache_intel.outputs.cache-hit != 'true'}}
+        env:
+          USE_MPI: ${{ matrix.mpi && 1 || 0 }}
         run: |
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
           sudo apt-get install -y intel-oneapi-compiler-fortran
+          if [ ${USE_MPI} = 1 ]; then
+            sudo apt-get install -y intel-oneapi-mpi-devel
+          fi
 
       - name: Setup python
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
           sudo apt-get install -y intel-oneapi-compiler-fortran
-          source /opt/intel/oneapi/compiler/latest/env/vars.sh
-          source /opt/intel/oneapi/setvars.sh
 
       - name: Setup python
         uses: actions/setup-python@v1
@@ -52,12 +50,19 @@ jobs:
       - name: Install Intel MKL
         run: sudo apt-get install -y intel-mkl
 
-      - name: Build
-        env:
-          COMPILER: ${{ matrix.compiler == 'intel' && 'ifort' || 'gfortran' }}
+      - name: Build (gfortran)
+        if: ${{ matrix.compiler == 'gfortran' }}
         run: |
-          ${COMPILER} --version
-          make COMPILER=${{ matrix.compiler }} MODE=ci
+          gfortran --version
+          make COMPILER=gfortran MODE=ci
+
+      - name: Build (intel)
+        if: ${{ matrix.compiler == 'intel' }}
+        run: |
+          source /opt/intel/oneapi/compiler/latest/env/vars.sh
+          source /opt/intel/oneapi/setvars.sh
+          ifort --version
+          make COMPILER=intel MODE=ci
 
       - name: Test
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           source /opt/intel/oneapi/setvars.sh
+          export I_MPI_F90=ifort
           ifort --version
           make COMPILER=intel MODE=ci ${MPI_PARAM}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ matrix.compiler == 'intel' }}
         uses: actions/cache@v2
         with:
-          key: oneapi-${{ matrix.os }}-${{ matrix.arch }}-MPI:{{ matrix.mpi }}
+          key: oneapi-${{ matrix.os }}-${{ matrix.arch }}-MPI:${{ matrix.mpi }}
           path: |
             /opt/intel/oneapi/*
             !/opt/intel/oneapi/conda_channel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,20 @@ jobs:
           #path: test/benchmarks
           #key: benchmark-data
 
+      - name: Restored cached Intel install
+        id: cache_intel
+        if: ${{ matrix.compiler == 'intel' }}
+        uses: actions/cache@v2
+        with:
+          key: oneapi-${{ matrix.os }}-${{ matrix.arch }}
+          path: |
+            /opt/intel/oneapi
+            !/opt/intel/oneapi/conda_channel
+            !/opt/intel/oneapi/debugger
+            !/opt/intel/oneapi/licensing
+
       - name: Setup Intel compiler and MPI
-        if: ${{ matrix.compiler  == 'intel' }}
+        if: ${{ matrix.compiler  == 'intel' && steps.cache_intel.outputs.cache-hit != 'true'}}
         run: |
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - x64
         compiler:
           - gfortran
+          - intel
     steps:
       - uses: actions/checkout@v2
 
@@ -30,6 +31,17 @@ jobs:
         #with:
           #path: test/benchmarks
           #key: benchmark-data
+
+      - name: Setup Intel compiler and MPI
+        if: ${{ matrix.compiler  == 'intel' }}
+        run: |
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
+          sudo apt-get install -y intel-oneapi-compiler-fortran
+          source /opt/intel/oneapi/compiler/latest/env/vars.sh
+          source /opt/intel/oneapi/setvars.sh
 
       - name: Setup python
         uses: actions/setup-python@v1
@@ -42,8 +54,8 @@ jobs:
 
       - name: Build
         run: |
-          gfortran --version
-          make COMPILER=gfortran MODE=ci
+          ${{ matrix.compiler }} --version
+          make COMPILER=${{ matrix.compiler }} MODE=ci
 
       - name: Test
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: TROVE ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.compiler }}
+    name: TROVE ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.compiler }} - MPI:${{ matrix.mpi }}
     env:
       OMP_NUM_THREADS: 1
     runs-on: ${{ matrix.os }}
@@ -21,6 +21,13 @@ jobs:
         compiler:
           - gfortran
           - intel
+        mpi:
+          - true
+          - false
+        exclude:
+          # only use MPI with intel
+          - compiler: gfortran
+            mpi: true
     steps:
       - uses: actions/checkout@v2
 
@@ -70,13 +77,19 @@ jobs:
 
       - name: Build (intel)
         if: ${{ matrix.compiler == 'intel' }}
+        env:
+          - MPI_PARAM: ${{ matrix.mpi && 'USE_MPI=1' || ''}}
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           source /opt/intel/oneapi/setvars.sh
           ifort --version
-          make COMPILER=intel MODE=ci
+          make COMPILER=intel MODE=ci ${MPI_PARAM}
 
       - name: Test
+        env:
+          - USE_MPI: ${{ matrix.mpi && 1 || 0 }}
+          # nproc is used in the test script for the number of processes
+          - nproc: ${{ matrix.mpi && 2 || 1 }}
         run: |
           if [[ -d "/opt/intel/oneapi" ]]; then
             source /opt/intel/oneapi/compiler/latest/env/vars.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           key: oneapi-${{ matrix.os }}-${{ matrix.arch }}
           path: |
-            /opt/intel/oneapi
+            /opt/intel/oneapi/*
             !/opt/intel/oneapi/conda_channel
             !/opt/intel/oneapi/debugger
             !/opt/intel/oneapi/licensing

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ ifeq ($(strip $(COMPILER)),intel)
 	ifeq ($(strip $(MODE)),debug)
 		FFLAGS += -O0 -g -traceback
 	else ifeq ($(strip $(MODE)),ci)
-		FFLAGS += -O2 -g
+		FFLAGS += -O0 -g
 	else
 		FFLAGS += -O3
 	endif

--- a/makefile
+++ b/makefile
@@ -22,6 +22,8 @@ ifeq ($(strip $(COMPILER)),intel)
 
 	ifeq ($(strip $(MODE)),debug)
 		FFLAGS += -O0 -g -traceback
+	else ifeq ($(strip $(MODE)),ci)
+		FFLAGS += -O2 -g
 	else
 		FFLAGS += -O3
 	endif

--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ else ifeq ($(strip $(COMPILER)),gfortran)
 	ifeq ($(strip $(MODE)),debug)
 		FFLAGS += -O0 -g -Wall -Wextra -fbacktrace
 	else ifeq ($(strip $(MODE)),ci)
-		FFLAGS += -O0 -g
+		FFLAGS += -O2 -g
 	else
 		FFLAGS += -O3
 	endif

--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ else ifeq ($(strip $(COMPILER)),gfortran)
 	ifeq ($(strip $(MODE)),debug)
 		FFLAGS += -O0 -g -Wall -Wextra -fbacktrace
 	else ifeq ($(strip $(MODE)),ci)
-		FFLAGS += -O2 -g
+		FFLAGS += -O0 -g
 	else
 		FFLAGS += -O3
 	endif

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ pot_user = pot_H2O_Conway
 
 COMPILER ?= intel
 MODE ?= release
-USE_MPI ?= 
+USE_MPI ?= 0
 
 # Intel
 #######
@@ -29,7 +29,7 @@ ifeq ($(strip $(COMPILER)),intel)
 	endif
 
 	LAPACK = -mkl=parallel
-	ifdef USE_MPI
+	ifneq ($(strip $(USE_MPI)),0)
 		LAPACK += -lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64
 	endif
 
@@ -54,7 +54,7 @@ else ifeq ($(strip $(COMPILER)),gfortran)
 	endif
 
 	LAPACK = -L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl
-	ifdef USE_MPI
+	ifneq ($(strip $(USE_MPI)),0)
 		LAPACK += -lmkl_blacs_intelmpi_lp64 -lmkl_scalapack_lp64
 	endif
 else
@@ -63,7 +63,7 @@ endif
 
 CPPFLAGS = -D_EXTFIELD_DEBUG_
 
-ifdef USE_MPI
+ifneq ($(strip $(USE_MPI)),0)
 	FOR = mpif90
 	FFLAGS += -DTROVE_USE_MPI_
 endif

--- a/test/run_regression_tests.sh
+++ b/test/run_regression_tests.sh
@@ -4,7 +4,8 @@ set -e
 
 exe_name=j-trove.x
 exe=../$exe_name
-nproc=1
+# Use 1 process unless we have specified differently (e.g. in CI)
+nproc=${nproc:-1}
 
 # Check exe is present
 if [ ! -f $exe ]; then

--- a/test/run_regression_tests.sh
+++ b/test/run_regression_tests.sh
@@ -28,6 +28,7 @@ for benchmark in H2CO; do
   cp $exe $wd
   cp benchmarks/$benchmark/input/*.inp $wd
   cp scripts/$benchmark/run_benchmark.sh $wd
+  cp scripts/set_io_format.sh $wd
 
   # Run benchmark
   pushd $wd

--- a/test/scripts/H2CO/compare_results.sh
+++ b/test/scripts/H2CO/compare_results.sh
@@ -11,7 +11,9 @@ quantum_files="eigen_descr0_1.chk eigen_descr0_2.chk eigen_descr0_3.chk eigen_de
 
 python compare_results.py --kind quantum --folder1 "$folder1" --folder2 "$folder2" $quantum_files
 
-python compare_results.py --kind intensity --precision 5e-6 --folder1 "$folder1" --folder2 "$folder2" file_intensity.out
+if [ ${USE_MPI} != 1 ]; then
+    python compare_results.py --kind intensity --precision 5e-6 --folder1 "$folder1" --folder2 "$folder2" file_intensity.out
+fi
 
 python compare_results.py --kind column --column 3 --precision 5e-3 --folder1 "$folder1" --folder2 "$folder2" external.chk
 

--- a/test/scripts/H2CO/run_benchmark.sh
+++ b/test/scripts/H2CO/run_benchmark.sh
@@ -27,7 +27,7 @@ echo "Current directory: `pwd`"
 echo "Using ${nproc} process(es)"
 
 for name in file{1..12} file_intensity; do
-  $LAUNCH ./$exe < $name.inp > $name.out
+  $LAUNCH ./$exe $name.inp > $name.out
 done
 
 echo "DONE"

--- a/test/scripts/H2CO/run_benchmark.sh
+++ b/test/scripts/H2CO/run_benchmark.sh
@@ -14,7 +14,11 @@ export OMP_NUM_THREADS=$nproc
 # Ensure stacksize unlimited (for fortran)
 ulimit -d unlimited
 
-LAUNCH="time"
+if [ ${USE_MPI} = 1 ]; then
+  LAUNCH="mpirun -ppn 1 -np $nproc"
+else
+  LAUNCH="time"
+fi
 
 echo "Time: `date`"
 echo "Current directory: `pwd`"

--- a/test/scripts/H2CO/run_benchmark.sh
+++ b/test/scripts/H2CO/run_benchmark.sh
@@ -16,6 +16,7 @@ ulimit -d unlimited
 
 if [ ${USE_MPI} = 1 ]; then
   LAUNCH="time mpirun -ppn 1 -np $nproc"
+  ./set_io_format.sh enable
   echo "Will run with MPI"
 else
   LAUNCH="time"
@@ -27,7 +28,7 @@ echo "Current directory: `pwd`"
 echo "Using ${nproc} process(es)"
 
 for name in file{1..12} file_intensity; do
-  $LAUNCH ./$exe $name.inp > $name.out
+  $LAUNCH ./$exe $name.inp -o $name > $name.out
 done
 
 echo "DONE"

--- a/test/scripts/H2CO/run_benchmark.sh
+++ b/test/scripts/H2CO/run_benchmark.sh
@@ -27,7 +27,12 @@ echo "Time: `date`"
 echo "Current directory: `pwd`"
 echo "Using ${nproc} process(es)"
 
-for name in file{1..12} file_intensity; do
+files_to_check=(file{1..12})
+if [ ${USE_MPI} != 1 ]; then
+  # The intensity file does not work with MPI at the moment
+  files_to_check+=(file_intensity)
+fi
+for name in ${files_to_check[@]}; do
   $LAUNCH ./$exe $name.inp -o $name > $name.out
 done
 

--- a/test/scripts/H2CO/run_benchmark.sh
+++ b/test/scripts/H2CO/run_benchmark.sh
@@ -15,13 +15,16 @@ export OMP_NUM_THREADS=$nproc
 ulimit -d unlimited
 
 if [ ${USE_MPI} = 1 ]; then
-  LAUNCH="mpirun -ppn 1 -np $nproc"
+  LAUNCH="time mpirun -ppn 1 -np $nproc"
+  echo "Will run with MPI"
 else
   LAUNCH="time"
+  echo "Will run without MPI"
 fi
 
 echo "Time: `date`"
 echo "Current directory: `pwd`"
+echo "Using ${nproc} process(es)"
 
 for name in file{1..12} file_intensity; do
   $LAUNCH ./$exe < $name.inp > $name.out

--- a/test/scripts/set_io_format.sh
+++ b/test/scripts/set_io_format.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+files=$(ls *.inp)
+option=$1
+
+if [[ $option == "enable" ]]; then
+  echo "enable"
+  for f in $files; do
+    if ! grep -qi MPIIO $f; then
+      sed -i '/eigenfunc/ a format MPIIO' $f
+    fi
+  done
+elif [[ $option == "disable" ]]; then
+  echo "disable"
+  for f in $files; do
+    if grep -qi MPIIO $f; then
+      sed -i '/MPIIO/d' $f
+    fi
+  done
+else
+  echo "options are enable or disable"
+fi


### PR DESCRIPTION
- [x] Install Intel compiler and MPI following [oneAPI examples](https://github.com/oneapi-src/oneapi-ci)
- [x] Cache oneAPI (see [example](https://github.com/oneapi-src/oneapi-ci/blob/c402f544b55bff90bf5b28fefbec7400126a5b9e/.github/workflows/build_all.yml))
- [x] Adjust Actions workflow and tests to run with MPI
  - [x] Avoid installing MKL twice when running with MPI
  - [x] Clean up
- [x] Make sure Makefile works correctly when combining `ci` mode and `USE_MPI`
  - [x] Make `USE_MPI` behave similar to the other options (`MODE`, `COMPILER`)