### PR TITLE
Small changes to unit test build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           - gfortran
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       #- name: Cache benchmark data
         #uses: actions/cache@v2
@@ -39,6 +41,11 @@ jobs:
 
       - name: Install Intel MKL
         run: sudo apt-get install -y intel-mkl
+
+      - name: Build pFUnit
+        run: |
+          mkdir -p lib/pFUnit/build
+          cd lib/pFUnit/build && cmake .. && make install
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,13 @@ jobs:
       - name: Install Intel MKL
         run: sudo apt-get install -y intel-mkl
 
+      - name: Build pFUnit
+        run: make COMPILER=gfortran install-pfunit
+
       - name: Build
         run: |
           gfortran --version
           make COMPILER=gfortran MODE=ci
 
       - name: Test
-        run: make COMPILER=gfortran install-pfunit test
+        run: make COMPILER=gfortran test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           - gfortran
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: recursive
 
       #- name: Cache benchmark data
         #uses: actions/cache@v2
@@ -42,15 +40,10 @@ jobs:
       - name: Install Intel MKL
         run: sudo apt-get install -y intel-mkl
 
-      - name: Build pFUnit
-        run: |
-          mkdir -p lib/pFUnit/build
-          cd lib/pFUnit/build && cmake .. && make install
-
       - name: Build
         run: |
           gfortran --version
           make COMPILER=gfortran MODE=ci
 
       - name: Test
-        run: make test
+        run: make COMPILER=gfortran install-pfunit test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/pFUnit"]
 	path = lib/pFUnit
-	url = git@github.com:Goddard-Fortran-Ecosystem/pFUnit.git
+	url = https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git

--- a/io_handler_mpi.f90
+++ b/io_handler_mpi.f90
@@ -1,6 +1,7 @@
 #include "errors.fpp"
 
 module io_handler_mpi
+#ifdef TROVE_USE_MPI_
   use mpi_f08
   use mpi_aux
   use io_handler_base
@@ -318,4 +319,5 @@ module io_handler_mpi
       print *, "reading 2D array to MPI IO"
     end subroutine
 
+#endif
 end module

--- a/io_handler_mpi.f90
+++ b/io_handler_mpi.f90
@@ -22,7 +22,6 @@ end select
 
 
 module io_handler_mpi
-#ifdef TROVE_USE_MPI_
   use mpi_f08
   use mpi_aux
   use io_handler_base
@@ -341,5 +340,4 @@ module io_handler_mpi
       print *, "reading 2D array to MPI IO"
     end subroutine
 
-#endif
 end module

--- a/io_handler_mpi.f90
+++ b/io_handler_mpi.f90
@@ -2,9 +2,17 @@
 
 #define MPI_WRAPPER(function, handle, obj, size, mytype, status, err) \
 select type(obj); \
-    type is (integer); \
+    type is (integer(ik)); \
+      call function(handle, obj, size, mytype, status, err); \
+    type is (integer(hik)); \
       call function(handle, obj, size, mytype, status, err); \
     type is (real); \
+      call function(handle, obj, size, mytype, status, err); \
+    type is (real(rk)); \
+      call function(handle, obj, size, mytype, status, err); \
+    type is (real(ark)); \
+      call function(handle, obj, size, mytype, status, err); \
+    type is (complex); \
       call function(handle, obj, size, mytype, status, err); \
     type is (character(len=*)); \
       call function(handle, obj, size, mytype, status, err); \
@@ -19,6 +27,7 @@ module io_handler_mpi
   use mpi_aux
   use io_handler_base
   use errors
+  use accuracy, only : rk, ark, ik, hik
 
   implicit none
 

--- a/io_handler_mpi.f90
+++ b/io_handler_mpi.f90
@@ -144,7 +144,7 @@ module io_handler_mpi
         byteSize = sizeof(object)
         mpiType = MPI_DOUBLE_COMPLEX
       type is (character(len=*))
-        byteSize = sizeof(object)
+        byteSize = len(object) * sizeof('a')
         mpiType = MPI_CHARACTER
       class default
         print *, "ERROR: Unknown type"

--- a/makefile
+++ b/makefile
@@ -159,7 +159,7 @@ regression-tests: $(TARGET)
 	cd test/regression; ./run_regression_tests.sh
 
 unit-tests: $(TARGET)
-	$(MAKE) -C test/unit test_io test_mpi_io
+	$(MAKE) -C test/unit LAPACK="$(LAPACK)" test_io test_mpi_io
 	echo "Running unit tests"
 	test/unit/test_io
 	mpirun -n 4 --mca opal_warn_on_missing_libcuda 0 test/unit/test_mpi_io

--- a/makefile
+++ b/makefile
@@ -105,6 +105,10 @@ OBJS := ${SRCS:.f90=.o}
 
 VPATH = $(SRCDIR):$(user_pot_dir):$(OBJDIR)
 
+TESTS = test_io
+ifdef USE_MPI
+	TESTS += test_mpi_io
+endif
 ################################################################################
 ## TARGETS
 ################################################################################
@@ -159,10 +163,11 @@ regression-tests: $(TARGET)
 	cd test/regression; ./run_regression_tests.sh
 
 unit-tests: $(TARGET)
-	$(MAKE) -C test/unit LAPACK="$(LAPACK)" test_io test_mpi_io
+	$(MAKE) -C test/unit LAPACK="$(LAPACK)" $(TESTS)
 	echo "Running unit tests"
 	test/unit/test_io
-	mpirun -n 4 --mca opal_warn_on_missing_libcuda 0 test/unit/test_mpi_io
+	# Not testing with MPI on CI yet, disable temporarily
+	# mpirun -n 4 --mca opal_warn_on_missing_libcuda 0 test/unit/test_mpi_io
 
 ################################################################################
 ## DEPENDENCIES

--- a/makefile
+++ b/makefile
@@ -202,7 +202,7 @@ mol_xy.o: mol_xy.f90 accuracy.o moltype.o
 mol_zxy2.o: mol_zxy2.f90 accuracy.o moltype.o
 mol_zxy3.o: mol_zxy3.f90 accuracy.o moltype.o lapack.o
 mpi_aux.o: mpi_aux.f90 accuracy.o timer.o
-perturbation.o: perturbation.f90 accuracy.o molecules.o moltype.o lapack.o plasma.o fields.o timer.o symmetry.o me_numer.o diag.o mpi_aux.o
+perturbation.o: perturbation.f90 accuracy.o molecules.o moltype.o lapack.o plasma.o fields.o timer.o symmetry.o me_numer.o diag.o mpi_aux.o io_handler_base.o io_handler_ftn.o io_handler_mpi.o
 plasma.o: plasma.f90 accuracy.o timer.o
 pot_abcd.o: pot_abcd.f90 accuracy.o moltype.o lapack.o
 pot_c2h4.o: pot_c2h4.f90 accuracy.o moltype.o

--- a/makefile
+++ b/makefile
@@ -88,6 +88,11 @@ OBJDIR=.
 user_pot_dir=.
 TARGET=$(BINDIR)/$(EXE)
 
+MPI_SRCS = 
+ifdef USE_MPI
+	MPI_SRCS += io_handler_mpi.f90
+endif
+
 SRCS := timer.f90 accuracy.f90 diag.f90 dipole.f90 extfield.f90 fields.f90 fwigxjpf.f90 input.f90 kin_xy2.f90 lapack.f90 \
 	me_bnd.f90 me_numer.f90 me_rot.f90 me_str.f90 \
 	mol_abcd.f90 mol_c2h4.f90 mol_c2h6.f90 mol_c3h6.f90 mol_ch3oh.f90 mol_xy.f90 \
@@ -97,11 +102,10 @@ SRCS := timer.f90 accuracy.f90 diag.f90 dipole.f90 extfield.f90 fields.f90 fwigx
 	pot_xy2.f90 pot_xy3.f90 pot_xy4.f90 pot_zxy2.f90 pot_zxy3.f90 \
 	prop_xy2.f90 prop_xy2_quad.f90 prop_xy2_spinrot.f90 prop_xy2_spinspin.f90 \
 	io_handler_base.f90 io_handler_ftn.f90 \
-	refinement.f90 richmol_data.f90 rotme_cart_tens.f90 symmetry.f90 tran.f90 trove.f90 $(pot_user).f90
-ifdef USE_MPI
-	SRCS += io_handler_mpi.f90
-endif
+	refinement.f90 richmol_data.f90 rotme_cart_tens.f90 symmetry.f90 tran.f90 trove.f90 $(pot_user).f90 $(MPI_SRCS)
+
 OBJS := ${SRCS:.f90=.o}
+MPI_OBJS := ${MPI_SRCS:.f90=.o}
 
 VPATH = $(SRCDIR):$(user_pot_dir):$(OBJDIR)
 
@@ -211,7 +215,7 @@ mol_xy.o: mol_xy.f90 accuracy.o moltype.o
 mol_zxy2.o: mol_zxy2.f90 accuracy.o moltype.o
 mol_zxy3.o: mol_zxy3.f90 accuracy.o moltype.o lapack.o
 mpi_aux.o: mpi_aux.f90 accuracy.o timer.o
-perturbation.o: perturbation.f90 accuracy.o molecules.o moltype.o lapack.o plasma.o fields.o timer.o symmetry.o me_numer.o diag.o mpi_aux.o io_handler_base.o io_handler_ftn.o io_handler_mpi.o
+perturbation.o: perturbation.f90 accuracy.o molecules.o moltype.o lapack.o plasma.o fields.o timer.o symmetry.o me_numer.o diag.o mpi_aux.o io_handler_base.o io_handler_ftn.o $(MPI_OBJS)
 plasma.o: plasma.f90 accuracy.o timer.o
 pot_abcd.o: pot_abcd.f90 accuracy.o moltype.o lapack.o
 pot_c2h4.o: pot_c2h4.f90 accuracy.o moltype.o

--- a/makefile
+++ b/makefile
@@ -133,7 +133,7 @@ ifneq ($(BINDIR),.)
 endif
 
 install-pfunit:
-	git submodule init # Make sure we have pfunit
+	git submodule update --init # Make sure we have pfunit
 	mkdir $(PFUNIT_DIR)/build
 	cd $(PFUNIT_DIR)/build; cmake ..
 	$(MAKE) -C $(PFUNIT_DIR)/build

--- a/perturbation.f90
+++ b/perturbation.f90
@@ -17824,6 +17824,9 @@ module perturbation
     integer(ik) :: Nsym,isym,Nsymi,Nsymj,jsymcoeff,Ntot
     integer(ik), allocatable :: isymcoeff_vs_isym(:,:)
     double precision,parameter :: a0 = -0.5d0
+
+    class(ioHandlerBase), allocatable :: ioHandler
+    type(ErrorType) :: err
       !
       call TimerStart('Contracted matelements-class-fast')
       !
@@ -17932,16 +17935,19 @@ module perturbation
           job_is ='Vib. matrix elements of the rot. kinetic part'
           call IOStart(trim(job_is),chkptIO)
 
-          open(chkptIO,form='unformatted',action='write',position='rewind',status='replace',file=job%kinetmat_file)
-          write(chkptIO) 'Start Kinetic part'
+          allocate(ioHandler, &
+            source=ioHandlerFTN(&
+            job%kinetmat_file, err, &
+            action='write', position='rewind', status='replace', form='unformatted'))
+          HANDLE_ERROR(err)
+          call ioHandler%write('Start Kinetic part')
           !
           ! store the bookkeeping information about the contr. basis set
           !
-          ! TODO change this to ioHandler
-          !call PTstore_icontr_cnu(PT%Maxcontracts,ioHandler,job%IOkinet_action)
+          call PTstore_icontr_cnu(PT%Maxcontracts,ioHandler,job%IOkinet_action)
           !
           if (job%vib_rot_contr) then
-            write(chkptIO) 'vib-rot'
+            call ioHandler%write('vib-rot')
           endif
           !
         endif 
@@ -18053,7 +18059,7 @@ module perturbation
           !
           if (trim(job%IOkinet_action)=='SAVE'.and..not.job%IOmatelem_split) then
             !
-            write(chkptIO) 'g_rot'
+            call ioHandler%write('g_rot')
             !
           endif
           !
@@ -18133,7 +18139,7 @@ module perturbation
                   if (job%IOmatelem_split) then
                      write(chkptIO_) grot_t
                   else
-                     write(chkptIO) grot_t
+                     call ioHandler%write(grot_t, mdimen)
                   endif
                   !
                 endif
@@ -18157,7 +18163,7 @@ module perturbation
           !
           if (trim(job%IOkinet_action)=='SAVE'.and..not.job%IOmatelem_split) then
             !
-            write(chkptIO) 'g_cor'
+            call ioHandler%write('g_cor')
             !
           endif
           !
@@ -18308,7 +18314,7 @@ module perturbation
                 if (job%IOmatelem_split) then
                    write(chkptIO_) grot_t
                 else
-                   write(chkptIO) grot_t
+                   call ioHandler%write(grot_t, mdimen)
                 endif
                 !
               endif
@@ -18353,7 +18359,7 @@ module perturbation
           if ((trim(job%IOkinet_action)=='SAVE'.or.trim(job%IOkinet_action)=='VIB_SAVE').and. & 
                   (.not.job%IOmatelem_split.or.job%iswap(1)==0.or.job%iswap(1)==(PT%Nmodes+3)*3 ) ) then
              !
-             write(chkptIO) 'hvib'
+             call ioHandler%write('hvib')
              !
           endif
           !
@@ -18563,10 +18569,8 @@ module perturbation
               enddo
               !$omp end parallel do
               !
-              !write(chkptIO) hvib_t
-              !
               if (trim(job%IOkinet_action)=='SAVE') then
-                   write(chkptIO) hvib_t
+                  call ioHandler%write(hvib_t)
               endif
               !
             endif 
@@ -18603,8 +18607,8 @@ module perturbation
         if ((trim(job%IOkinet_action)=='SAVE'.or.trim(job%IOkinet_action)=='VIB_SAVE').and.&
            (.not.job%IOmatelem_split.or.job%iswap(1)==0 )) then
           !
-          write(chkptIO) 'End Kinetic part'
-          close(chkptIO,status='keep')
+          call ioHandler%write('End Kinetic part')
+          deallocate(ioHandler)
           !
         endif 
         !
@@ -38246,6 +38250,9 @@ end subroutine combinations
     type(me_type), allocatable :: vpot_me(:)
     type(me_type), allocatable :: pseudo_me(:)
     type(me_type), allocatable :: extF_me(:)
+
+    class(ioHandlerBase), allocatable :: ioHandler
+    type(ErrorType) :: err
       !
       call TimerStart('Contracted matelements-class-fast')
       !
@@ -38348,16 +38355,20 @@ end subroutine combinations
           job_is ='Vib. matrix elements of the rot. kinetic part'
           call IOStart(trim(job_is),chkptIO)
           !
-          open(chkptIO,form='unformatted',action='write',position='rewind',status='replace',file=job%kinetmat_file)
-          write(chkptIO) 'Start Kinetic part'
+          allocate(ioHandler, &
+            source=ioHandlerFTN(&
+            job%kinetmat_file, err, &
+            action='write', position='rewind', status='replace', form='unformatted'))
+          HANDLE_ERROR(err)
+
+          call ioHandler%write('Start Kinetic part')
           !
           ! store the bookkeeping information about the contr. basis set
           !
-          ! TODO change me to ioHandler
-          !call PTstore_icontr_cnu(PT%Maxcontracts,ioHandler,job%IOkinet_action)
+          call PTstore_icontr_cnu(PT%Maxcontracts,ioHandler,job%IOkinet_action)
           !
           if (job%vib_rot_contr) then
-            write(chkptIO) 'vib-rot'
+            call ioHandler%write('vib-rot')
           endif
           !
         endif 
@@ -38430,7 +38441,7 @@ end subroutine combinations
           !
           if (trim(job%IOkinet_action)=='SAVE'.and..not.job%IOmatelem_split) then
             !
-            write(chkptIO) 'g_rot'
+            call ioHandler%write('g_rot')
             !
           endif 
           !
@@ -38504,7 +38515,7 @@ end subroutine combinations
                   if (job%IOmatelem_split) then
                      write(chkptIO_) grot_t
                   else
-                     write(chkptIO) grot_t
+                     call ioHandler%write(grot_t, mdimen)
                   endif
                   !
                 endif
@@ -38528,7 +38539,7 @@ end subroutine combinations
           !
           if (trim(job%IOkinet_action)=='SAVE'.and..not.job%IOmatelem_split) then
             !
-            write(chkptIO) 'g_cor'
+            call ioHandler%write('g_cor')
             !
           endif
           !
@@ -38645,7 +38656,7 @@ end subroutine combinations
                 if (job%IOmatelem_split) then
                    write(chkptIO_) grot_t
                 else
-                   write(chkptIO) grot_t
+                  call ioHandler%write(grot_t, mdimen)
                 endif
                 !
               endif
@@ -38690,7 +38701,7 @@ end subroutine combinations
           if ((trim(job%IOkinet_action)=='SAVE'.or.trim(job%IOkinet_action)=='VIB_SAVE').and. & 
                   (.not.job%IOmatelem_split.or.job%iswap(1)==0.or.job%iswap(1)==(PT%Nmodes+3)*3 ) ) then
              !
-             write(chkptIO) 'hvib'
+             call ioHandler%write('hivb')
              !
           endif
           !
@@ -38825,10 +38836,8 @@ end subroutine combinations
               enddo
               !$omp end parallel do
               !
-              !write(chkptIO) hvib_t
-              !
               if (trim(job%IOkinet_action)=='SAVE') then
-                   write(chkptIO) hvib_t
+                  call ioHandler%write(hvib_t, mdimen)
               endif
               !
             endif 
@@ -38865,8 +38874,8 @@ end subroutine combinations
         if ((trim(job%IOkinet_action)=='SAVE'.or.trim(job%IOkinet_action)=='VIB_SAVE').and.&
            (.not.job%IOmatelem_split.or.job%iswap(1)==0 )) then
           !
-          write(chkptIO) 'End Kinetic part'
-          close(chkptIO,status='keep')
+          call ioHandler%write('End Kinetic part')
+          deallocate(ioHandler)
           !
         endif 
         !

--- a/test/unit/makefile
+++ b/test/unit/makefile
@@ -8,11 +8,6 @@ include $(BASE_DIR)/lib/pFUnit/build/PFUNIT.mk
 FFLAGS += $(PFUNIT_EXTRA_FFLAGS)
 FFLAGS += -I../..
 
-LAPACK = -L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl
-ifdef USE_MPI
-LAPACK += -lmkl_blacs_openmpi_lp64 -lmkl_scalapack_lp64
-endif
-
 test_io_TESTS := test_io.pf
 test_io_OTHER_SRCS := $(addprefix $(BASE_DIR)/, io_handler_ftn.f90 io_handler_base.f90 )
 $(eval $(call make_pfunit_test,test_io))
@@ -20,7 +15,7 @@ $(eval $(call make_pfunit_test,test_io))
 ifdef USE_MPI
 FFLAGS += -DTROVE_USE_MPI_
 test_mpi_io_TESTS := test_mpi_io.pf
-test_mpi_io_OTHER_LIBRARIES := ${LAPACK}
+test_mpi_io_OTHER_LIBRARIES := ${LAPACK} # passed in from base makefile
 test_mpi_io_OTHER_SRCS := $(addprefix $(BASE_DIR)/, io_handler_mpi.f90 io_handler_base.f90 mpi_aux.f90 timer.f90 accuracy.f90)
 $(eval $(call make_pfunit_test,test_mpi_io))
 endif


### PR DESCRIPTION
- Explicitly list I/O handlers as dependencies for pertubation (or serial `make` fails)
- Ignore `ioHandlerMPI` in build if not using MPI
- Reenable writing for some files to get regression tests passing
- Fixes to `ioHandlerMPI` for Intel compiler
- Fixes for running on GitHub Actions (incl. temporarily disabling MPI unit tests)