### PR TITLE
Fix/ch4 file2 name

### DIFF
--- a/fields.f90
+++ b/fields.f90
@@ -14555,7 +14555,9 @@ end subroutine check_read_save_none
             !
             fl => trove%g_cor(k1,k2) 
             !
-            call write_ascii(k1,k2,fl%Ncoeff,fl%Npoints,chkptIO_kin,fl%ifromsparse,fl%field)
+            if (associated(fl)) then
+              call write_ascii(k1,k2,fl%Ncoeff,fl%Npoints,chkptIO_kin,fl%ifromsparse,fl%field)
+            endif
             !
           enddo
         enddo

--- a/makefile
+++ b/makefile
@@ -46,7 +46,7 @@ else ifeq ($(strip $(COMPILER)),gfortran)
 	endif
 
 	ifeq ($(strip $(MODE)),debug)
-		FFLAGS += -O0 -g -Wall -Wextra -fbacktrace -finit-local-zero -ffpe-trap=invalid,zero,overflow -fbounds-check -fcheck=all
+		FFLAGS += -O0 -g -Wall -Wextra -fbacktrace -finit-local-zero -ffpe-trap=invalid,zero,overflow # -fbounds-check -fcheck=all
 	else ifeq ($(strip $(MODE)),ci)
 		FFLAGS += -O2 -g
 	else

--- a/perturbation.f90
+++ b/perturbation.f90
@@ -8513,7 +8513,7 @@ module perturbation
 
     call MPI_File_open(mpi_comm_world, filename, amode, mpi_info_null, fileh, ierr)
     if (ierr.gt.0) then
-      if (mpi_rank .eq. 0) write(*,*) "Error opening MPI-IO-formatted Vib. kinetic checkpoint file.", filename
+      if (mpi_rank .eq. 0) write(*,*) "Error opening MPI-IO-formatted Vib. kinetic checkpoint file. ", filename
       stop "MPI_PTrestore_rot_kinetic_matrix_elements - Error opening MATELEM MPI-IO input file"
     endif
 
@@ -8600,10 +8600,7 @@ module perturbation
       !TODO - MPI-compatible IOStart
       !call IOStart(trim(job_id),fileh)
 
-      !TODO set filename dynamically
-      filename = trim(job%matelem_suffix)//'.chk'
-
-      call open_chkptfile_mpi(fileh, filename, 'read')
+      call open_chkptfile_mpi(fileh, job%kinetmat_file, 'read')
 
       !Collective read woo
       call MPI_File_read_all(fileh, readbuf, 7, mpi_character, mpi_status_ignore, ierr)


### PR DESCRIPTION
This PR fixes the bug where TROVE could not find the `matelem.chk` file because it's actually named `contr_matelem.chk`. It also fixes an unassociated array access.